### PR TITLE
Multiple contracts in eosio::contract, and support for typedefs #5

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -2870,6 +2870,8 @@ struct EosioOrder {
 
 using EosioOrders = SmallVector<EosioOrder, 2>;
 
+using EosioContracts = SmallVector<std::string, 2>;
+
 /// Base class for declarations which introduce a typedef-name.
 class TypedefNameDecl : public TypeDecl, public Redeclarable<TypedefNameDecl> {
   struct LLVM_ALIGNAS(8) ModedTInfo {
@@ -2975,6 +2977,9 @@ public:
   std::string getEosioTable() const;
   bool hasEosioScopeType() const;
   std::string getEosioScopeType() const;
+
+  bool hasEosioContracts() const;
+  EosioContracts getEosioContracts() const;
 private:
   bool isTransparentTagSlow() const;
 };

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -953,7 +953,7 @@ def EosioRicardian : InheritableAttr {
 def EosioContract : InheritableAttr {
    let Spellings = [CXX11<"eosio", "contract">, GNU<"eosio_contract">];
    let Args = [StringArgument<"name", 1>];
-   let Subjects = SubjectList<[CXXRecord, CXXMethod]>;
+   let Subjects = SubjectList<[CXXRecord, CXXMethod, TypedefName]>;
    let Documentation = [EosioContractDocs];
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4450,6 +4450,15 @@ std::string TypedefNameDecl::getEosioScopeType()const {
   return getAttr<EosioScopeTypeAttr>()->getType();
 }
 
+bool TypedefNameDecl::hasEosioContracts()const { return hasAttr<EosioContractAttr>(); }
+EosioContracts TypedefNameDecl::getEosioContracts()const {
+  EosioContracts ret;
+  for (auto* attr: getAttrs()) {
+    if (auto contract = dyn_cast<EosioContractAttr>(attr)) ret.push_back(contract->getName());
+  }
+  return ret;
+}
+
 bool TypedefNameDecl::isTransparentTagSlow() const {
   auto determineIsTransparent = [&]() {
     if (auto *TT = getUnderlyingType()->getAs<TagType>()) {


### PR DESCRIPTION
## Introduction
In EOS, attribute `[[eosio::contract]]` was being added to declarations like events and actions to figure out in what ABI file they should be described. Example: `[[eosio::contract("commun.point")]]` means `commun.point.abi`.

## In this PR
- Adds support of `[[eosio::contract]]` to typedefs (i.e. `using blabla = multi_index...`).
- And adds possiblity to declare it with multiple contract names - `[[using eosio: contract("commun.gallery"), contract("commun.publication")]]` - to support "library contracts" like our gallery. EOSIO way with 1 argument still supported.