### PR TITLE
Templated getAttrs() and multiple eosio::contract for records and met…

### DIFF
--- a/include/clang/AST/DeclBase.h
+++ b/include/clang/AST/DeclBase.h
@@ -478,8 +478,19 @@ public:
   AttrVec &getAttrs() {
     return const_cast<AttrVec&>(const_cast<const Decl*>(this)->getAttrs());
   }
-
   const AttrVec &getAttrs() const;
+
+  template<typename T>
+  SmallVector<T*, 4> getAttrs() const {
+    SmallVector<T*, 4> ret;
+    for (auto* attr: getAttrs()) {
+      if (auto spec_attr = dyn_cast<T>(attr)) {
+        ret.push_back(spec_attr);
+      }
+    }
+    return ret;
+  }
+
   void dropAttrs();
 
   void addAttr(Attr *A) {

--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -734,7 +734,7 @@ public:
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioTableAttr*  getEosioTableAttr() const { return getAttr<EosioTableAttr>(); }
   EosioEventAttr*  getEosioEventAttr() const { return getAttr<EosioEventAttr>(); }
-  EosioContractAttr*  getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
+  SmallVector<EosioContractAttr*, 4>  getEosioContractAttrs() const { return getAttrs<EosioContractAttr>(); }
   EosioRicardianAttr*  getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
 
   CXXRecordDecl *getCanonicalDecl() override {
@@ -2075,7 +2075,7 @@ public:
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioNotifyAttr* getEosioNotifyAttr() const { return getAttr<EosioNotifyAttr>(); }
-  EosioContractAttr* getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
+  SmallVector<EosioContractAttr*, 4>  getEosioContractAttrs() const { return getAttrs<EosioContractAttr>(); }
   EosioRicardianAttr* getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
 
   /// Returns true if the given operator is implicitly static in a record


### PR DESCRIPTION
Resolve #7:
- Added templated `getAttrs` method which works like `getAttr` but returns few attributes. I think it is useful feature for clang :1st_place_medal:  
- Using this method implemented selection of multiple `eosio::contract` attributes. Now no need to write this complicating logic in CDT code.