### PR TITLE
eosio::no_dispatch attribute #11

### DIFF
--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -727,6 +727,7 @@ public:
   using base_class_const_iterator = const CXXBaseSpecifier *;
   bool isEosioContract() const { return hasAttr<EosioContractAttr>(); }
   bool isEosioAction() const { return hasAttr<EosioActionAttr>(); }
+  bool hasEosioNoDispatch() const { return hasAttr<EosioNoDispatchAttr>(); }
   bool isEosioTable() const { return hasAttr<EosioTableAttr>(); }
   bool isEosioEvent() const { return hasAttr<EosioEventAttr>(); }
   bool isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
@@ -2070,6 +2071,7 @@ public:
   bool isStatic() const;
   bool isInstance() const { return !isStatic(); }
   bool isEosioAction() const { return hasAttr<EosioActionAttr>(); }
+  bool hasEosioNoDispatch() const { return hasAttr<EosioNoDispatchAttr>(); }
   bool isEosioNotify() const { return hasAttr<EosioNotifyAttr>(); }
   bool isEosioContract() const { return hasAttr<EosioContractAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -997,6 +997,13 @@ def EosioAction : InheritableAttr {
    let Documentation = [EosioActionDocs];
 }
 
+def EosioNoDispatch : InheritableAttr {
+   let Spellings = [CXX11<"eosio", "no_dispatch">, GNU<"eosio_no_dispatch">];
+   let Subjects = SubjectList<[CXXRecord, CXXMethod]>;
+   let MeaningfulToClassTemplateDefinition = 1;
+   let Documentation = [EosioNoDispatchDocs];
+}
+
 def EosioOrder : InheritableAttr {
    let Spellings = [CXX11<"eosio", "order">, GNU<"eosio_order">];
    let Args = [StringArgument<"Field">, StringArgument<"Order", 1>];

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -887,6 +887,13 @@ The ``eosio::action`` attribute marks a method as being an eosio action.
   }];
 }
 
+def EosioNoDispatchDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``eosio::no_dispatch`` attribute marks an action as not to be added to dispatcher of contract.
+  }];
+}
+
 def EosioOrderDocs : Documentation {
   let Category = DocCatType;
   let Content = [{

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -469,6 +469,12 @@ static void handleEosioActionAttribute(Sema &S, Decl *D, const AttributeList &AL
                                 AL.getAttributeSpellingListIndex()));
 }
 
+static void handleEosioNoDispatchAttribute(Sema &S, Decl *D, const AttributeList &AL) {
+  D->addAttr(::new (S.Context)
+                 EosioNoDispatchAttr(AL.getRange(), S.Context,
+                                AL.getAttributeSpellingListIndex()));
+}
+
 static void handleEosioOrderAttribute(Sema &S, Decl *D, const AttributeList &AL) {
   StringRef Field, Order = "asc";
   S.checkStringLiteralArgumentAttr(AL, 0, Field);
@@ -5966,6 +5972,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case AttributeList::AT_EosioAction:
     handleEosioActionAttribute(S, D, AL);
+    break;
+  case AttributeList::AT_EosioNoDispatch:
+    handleEosioNoDispatchAttribute(S, D, AL);
     break;
   case AttributeList::AT_EosioOrder:
     handleEosioOrderAttribute(S, D, AL);


### PR DESCRIPTION
Resolve #11.
Adds attribute allows us to mark actions which should be added to ABI but should not to dispatch (internal actions of cyber.bios, cyber.domain and etc. which implemented in core)