### PR TITLE
[[eosio::abi_ignore]] attribute #13

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -3655,6 +3655,7 @@ public:
   }
 
   bool isEosioIgnore() const;
+  bool isEosioABIIgnore() const;
 
   bool hasFlexibleArrayMember() const { return HasFlexibleArrayMember; }
   void setHasFlexibleArrayMember(bool V) { HasFlexibleArrayMember = V; }

--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -730,6 +730,7 @@ public:
   bool isEosioTable() const { return hasAttr<EosioTableAttr>(); }
   bool isEosioEvent() const { return hasAttr<EosioEventAttr>(); }
   bool isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
+  bool isEosioABIIgnore() const { return hasAttr<EosioABIIgnoreAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioTableAttr*  getEosioTableAttr() const { return getAttr<EosioTableAttr>(); }

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -936,6 +936,13 @@ def EosioIgnore : InheritableAttr {
    let Documentation = [EosioIgnoreDocs];
 }
 
+def EosioABIIgnore : InheritableAttr {
+   let Spellings = [CXX11<"eosio", "abi_ignore">, GNU<"eosio_abi_ignore">];
+   let Args = [StringArgument<"name", 1>];
+   let Subjects = SubjectList<[CXXRecord, Record]>;
+   let Documentation = [EosioABIIgnoreDocs];
+}
+
 def EosioNotify : InheritableAttr {
    let Spellings = [CXX11<"eosio", "on_notify">, GNU<"eosio_on_notify">];
    let Args = [StringArgument<"name">];

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -859,6 +859,13 @@ The ``eosio::ignore`` attribute marks a template struct as an ignorable type.
   }];
 }
 
+def EosioABIIgnoreDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``eosio::abi_ignore`` attribute marks a template struct as an ignorable type. Supports structs having typedef aliases, or nested inside vectors, variants, etc.
+  }];
+}
+
 def EosioRicardianDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4011,6 +4011,7 @@ bool RecordDecl::isInjectedClassName() const {
 }
 
 bool RecordDecl::isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
+bool RecordDecl::isEosioABIIgnore() const { return hasAttr<EosioABIIgnoreAttr>(); }
 
 bool RecordDecl::isLambda() const {
   if (auto RD = dyn_cast<CXXRecordDecl>(this))

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -5964,6 +5964,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_EosioIgnore:
     handleSimpleAttribute<EosioIgnoreAttr>(S, D, AL);
     break;
+  case AttributeList::AT_EosioABIIgnore:
+    handleSimpleAttribute<EosioABIIgnoreAttr>(S, D, AL);
+    break;
   case AttributeList::AT_EosioAction:
     handleEosioActionAttribute(S, D, AL);
     break;


### PR DESCRIPTION
Resolve #13.
This PR introduces new attribute which allows to ignore structs in ABI with more robust way that EOS's `[[eosio::ignore]]` attribute.

Behavior of new attribute can be seen in this PR: https://github.com/cyberway/cyberway.cdt/pull/160